### PR TITLE
Update nodenv to v1.3.1

### DIFF
--- a/12.14.1-stretch/Dockerfile
+++ b/12.14.1-stretch/Dockerfile
@@ -1,0 +1,41 @@
+FROM node:12.14.1-stretch-slim
+
+# Preset locale to en_US.UTF-8
+# https://docs.docker.com/samples/library/debian/#locales
+RUN apt-get update && apt-get install -y locales \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* \
+    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+RUN apt-get update && apt-get install -y  \
+        git \
+        curl \
+        pkg-config \
+        libx11-dev \
+        libxkbfile-dev \
+        libsecret-1-dev \
+        node-gyp \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV NODENV_ROOT /opt/nodenv
+ENV PATH "$NODENV_ROOT/shims:$NODENV_ROOT/bin:$PATH"
+
+# Install nodenv
+RUN nodenv_version="v1.3.1" \
+  && git clone https://github.com/nodenv/nodenv.git ${NODENV_ROOT} \
+  && cd ${NODENV_ROOT} && git checkout ${nodenv_version} \
+  && src/configure && make -C src \
+  && node_build_version="b4ec27b0e8569e20a03aa73a0b83a8fac7bc790f" \
+  && git clone https://github.com/nodenv/node-build.git ${NODENV_ROOT}/plugins/node-build \
+  && cd ${NODENV_ROOT}/plugins/node-build && git checkout ${node_build_version} \
+  && node_build_jxcore_version="v1.0.1" \
+  && git clone https://github.com/nodenv/node-build-jxcore.git $(nodenv root)/plugins/node-build-jxcore \
+  && cd $(nodenv root)/plugins/node-build-jxcore && git checkout ${node_build_jxcore_version} \
+  && npm_migrate_version="v0.1.1" \
+  && git clone https://github.com/nodenv/nodenv-npm-migrate.git ${NODENV_ROOT}/plugins/nodenv-npm-migrate \
+  && cd ${NODENV_ROOT}/plugins/nodenv-npm-migrate && git checkout ${npm_migrate_version} \
+  && find ${NODENV_ROOT} -type d -name ".git" -exec rm -r "{}" \+ \
+  && curl -fsSL https://github.com/nodenv/nodenv-installer/raw/master/bin/nodenv-doctor | bash \
+  && nodenv install --list


### PR DESCRIPTION
nodenvの新しいバージョンのイメージを追加しました。

Nodejs：12.14.1
nodenv：v1.3.1
node-build：master/b4ec27b

https://hub.docker.com/layers/conchoid/docker-nodenv/v1.3.1-9-12.14.1-stretch/images/sha256-e30df2bdd7549c02d250a0b85da1c49b72c6c666472acb9d9482afdcc57f143b
