### PR TITLE
Add git-lfs

### DIFF
--- a/17.2.0-buster/Dockerfile
+++ b/17.2.0-buster/Dockerfile
@@ -20,6 +20,13 @@ RUN apt-get update && apt-get install -y \
       pkg-config \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+
+RUN echo "deb http://ftp.debian.org/debian bullseye-backports main" > /etc/apt/sources.list.d/backports.list \
+    && apt-get update \
+    && apt-get install -y -t bullseye-backports git-lfs \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8


### PR DESCRIPTION
nodeenvにgit-lfsを追加しました。

dockerHubには書きタグでPush済みです。
`conchoid/docker-nodenv:v1.4.0-2-17.2.0-buster`