### PR TITLE
Update trixie / update node to 24.12.0

### DIFF
--- a/.update/update.md
+++ b/.update/update.md
@@ -2,6 +2,7 @@
 
 ## 概要
 docker-nodenv/24.2.0-bookworm/Dockerfileのベースイメージを `node:X.X.X-bookworm-slim` (Debian 12) から `node:X.X.X-trixie-slim` (Debian 13) に更新する。
+システムのデフォルトのnode versionは 最新のLTSとする。(https://nodejs.org/ja/about/previous-releases)
 
 ## 更新手順
 

--- a/.update/update.md
+++ b/.update/update.md
@@ -1,0 +1,65 @@
+# Dockerfile ベースイメージ更新手順
+
+## 概要
+docker-nodenv/24.2.0-bookworm/Dockerfileのベースイメージを `node:X.X.X-bookworm-slim` (Debian 12) から `node:X.X.X-trixie-slim` (Debian 13) に更新する。
+
+## 更新手順
+
+### 1. ベースイメージの更新
+Dockerfileの1-7行目を以下のように変更する：
+
+**変更前:**
+```dockerfile
+FROM node:18.20.8-bookworm-slim AS node18
+FROM node:20.19.2-bookworm-slim AS node20
+FROM node:22.16.0-bookworm-slim AS node22
+FROM node:23.11.1-bookworm-slim AS node23
+FROM node:24.2.0-bookworm-slim AS node24
+
+FROM node:24.2.0-bookworm-slim
+```
+
+**変更後:**
+```dockerfile
+FROM node:18.20.8-trixie-slim AS node18
+FROM node:20.19.2-trixie-slim AS node20
+FROM node:22.16.0-trixie-slim AS node22
+FROM node:23.11.1-trixie-slim AS node23
+FROM node:24.2.0-trixie-slim AS node24
+
+FROM node:24.2.0-trixie-slim
+```
+
+### 2. 動作確認
+以下のコマンドでDockerイメージをビルドし、正常に動作することを確認する：
+
+```bash
+cd docker-nodenv
+docker build -t conchoid/docker-nodenv:v1.5.0-1-24.2.0-trixie -f 24.2.0-trixie/Dockerfile .
+```
+
+### 3. 互換性チェック
+Debian 13への更新により、以下の点を確認する：
+
+- パッケージの互換性（apt-getでインストールしているパッケージが利用可能か）
+- nodenvの動作確認
+- node-buildの動作確認
+- Node.js各バージョン（18.20.8, 20.19.2, 22.16.0, 23.11.1, 24.2.0）のインストール確認
+- npmの動作確認
+- pnpmのインストール確認
+- ロケール設定の確認
+
+### 4. テスト実行
+実際のNode.jsプロジェクトでイメージを使用し、以下を確認する：
+
+- ビルドが正常に完了するか
+- 依存関係の解決が正常に行われるか
+- 実行時エラーが発生しないか
+- nodenvによるNode.jsバージョン切り替えが正常に動作するか
+
+## 注意事項
+- Debian 13 (trixie) は比較的新しいリリースのため、一部のパッケージやツールのバージョンが変更されている可能性がある
+- 問題が発生した場合は、パッケージのバージョン指定や代替パッケージの検討が必要になる場合がある
+- **apt-getでインストールしているライブラリは必要なライブラリなので、trixieでもインストールを行う必要がある**
+- ビルド後は、nodenv、node-build、各Node.jsバージョン、npm、pnpmが正常にインストールされていることを確認すること
+

--- a/24.13.0-bookworm/Dockerfile
+++ b/24.13.0-bookworm/Dockerfile
@@ -1,0 +1,91 @@
+FROM node:18.20.8-bookworm-slim AS node18
+FROM node:20.20.1-bookworm-slim AS node20
+FROM node:22.22.1-bookworm-slim AS node22
+FROM node:23.11.1-bookworm-slim AS node23
+FROM node:24.13.0-bookworm-slim AS node24
+FROM node:25.8.1-bookworm-slim AS node25
+
+FROM node:24.13.0-bookworm-slim
+
+# install build deps and set locale (Preset locale to en_US.UTF-8)
+RUN apt-get update && apt-get install -y \
+      curl \
+      git \
+      git-lfs \
+      libsecret-1-dev \
+      libx11-dev \
+      libxkbfile-dev \
+      locales \
+      node-gyp \
+      pkg-config \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* \
+    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
+
+ENV NODENV_ROOT=/opt/nodenv
+ENV PATH="$NODENV_ROOT/shims:$NODENV_ROOT/bin:$PATH"
+
+# Install nodenv
+RUN nodenv_version="v1.6.2" \
+  && git clone https://github.com/nodenv/nodenv.git ${NODENV_ROOT} \
+  && cd ${NODENV_ROOT} && git checkout ${nodenv_version} \
+  && node_build_version="v5.4.30" \
+  && git clone https://github.com/nodenv/node-build.git ${NODENV_ROOT}/plugins/node-build \
+  && cd ${NODENV_ROOT}/plugins/node-build && git checkout ${node_build_version} \
+  && git clone https://github.com/nodenv/node-build-jxcore.git $(nodenv root)/plugins/node-build-jxcore \
+  && cd $(nodenv root)/plugins/node-build-jxcore && git checkout 1b6cdf343b767e77b9f1522d5c9fa111c5373794 \
+  && npm_migrate_version="v0.1.1" \
+  && git clone https://github.com/nodenv/nodenv-npm-migrate.git ${NODENV_ROOT}/plugins/nodenv-npm-migrate \
+  && cd ${NODENV_ROOT}/plugins/nodenv-npm-migrate && git checkout ${npm_migrate_version} \
+  && find ${NODENV_ROOT} -type d -name ".git" -exec rm -r "{}" \+ \
+  && curl -fsSL https://github.com/nodenv/nodenv-installer/raw/master/bin/nodenv-doctor | bash \
+  && nodenv install --list
+
+
+# Install all latest major Nodejs versions excludes older than one year since EOL.
+# https://github.com/nodejs/Release#end-of-life-releases
+
+ENV ROCRO_NODE18=18.20.8
+ENV ROCRO_NODE20=20.20.1
+ENV ROCRO_NODE22=22.22.1
+ENV ROCRO_NODE23=23.11.1
+ENV ROCRO_NODE24=24.13.0
+ENV ROCRO_NODE25=25.8.1
+ENV ROCRO_PREINSTALLED_VERSIONS="\
+${ROCRO_NODE18}\n\
+${ROCRO_NODE20}\n\
+${ROCRO_NODE22}\n\
+${ROCRO_NODE23}\n\
+${ROCRO_NODE24}\n\
+${ROCRO_NODE25}"
+
+COPY --from=node18 "/usr/local/bin/node" "${NODENV_ROOT}/versions/${ROCRO_NODE18}/bin/"
+COPY --from=node20 "/usr/local/bin/node" "${NODENV_ROOT}/versions/${ROCRO_NODE20}/bin/"
+COPY --from=node22 "/usr/local/bin/node" "${NODENV_ROOT}/versions/${ROCRO_NODE22}/bin/"
+COPY --from=node23 "/usr/local/bin/node" "${NODENV_ROOT}/versions/${ROCRO_NODE23}/bin/"
+COPY --from=node24 "/usr/local/bin/node" "${NODENV_ROOT}/versions/${ROCRO_NODE24}/bin/"
+COPY --from=node25 "/usr/local/bin/node" "${NODENV_ROOT}/versions/${ROCRO_NODE25}/bin/"
+
+COPY --from=node18 "/usr/local/lib/node_modules" "${NODENV_ROOT}/versions/${ROCRO_NODE18}/lib/node_modules"
+COPY --from=node20 "/usr/local/lib/node_modules" "${NODENV_ROOT}/versions/${ROCRO_NODE20}/lib/node_modules"
+COPY --from=node22 "/usr/local/lib/node_modules" "${NODENV_ROOT}/versions/${ROCRO_NODE22}/lib/node_modules"
+COPY --from=node23 "/usr/local/lib/node_modules" "${NODENV_ROOT}/versions/${ROCRO_NODE23}/lib/node_modules"
+COPY --from=node24 "/usr/local/lib/node_modules" "${NODENV_ROOT}/versions/${ROCRO_NODE24}/lib/node_modules"
+COPY --from=node25 "/usr/local/lib/node_modules" "${NODENV_ROOT}/versions/${ROCRO_NODE25}/lib/node_modules"
+
+RUN mkdir -p "${NODENV_ROOT}/versions/${ROCRO_NODE20}/bin/" "${NODENV_ROOT}/versions/${ROCRO_NODE20}/lib/" \
+    && cp "$(nodenv which node)" "${NODENV_ROOT}/versions/${ROCRO_NODE20}/bin/" \
+    && cp -R "/usr/local/lib/node_modules" "${NODENV_ROOT}/versions/${ROCRO_NODE20}/lib/" \
+    && echo ${ROCRO_PREINSTALLED_VERSIONS} | while read version;do \
+      npm install -g pnpm@10.12.1 \
+      && NPM_SRC="${NODENV_ROOT}/versions/${version}/lib/node_modules/npm/bin/npm-cli.js" \
+      && NPM_DST="${NODENV_ROOT}/versions/${version}/bin/npm" \
+      # Override the shebang line of npm-cli.js to use the "node" path dynamically.
+      && sed -i -E "1s/#.+/#!\/usr\/bin\/env node/" "${NPM_SRC}" \
+      && ln -s -f "${NPM_SRC}" "${NPM_DST}";done \
+    && nodenv rehash \
+    && npm set progress false --global --quiet \
+    && [ "$(nodenv versions --bare | xargs)" = "$ROCRO_NODE18 $ROCRO_NODE20 $ROCRO_NODE22 $ROCRO_NODE23 $ROCRO_NODE24 $ROCRO_NODE25" ]

--- a/24.13.0-trixie/Dockerfile
+++ b/24.13.0-trixie/Dockerfile
@@ -1,0 +1,91 @@
+FROM node:18.20.8-bookworm-slim AS node18
+FROM node:20.20.1-trixie-slim AS node20
+FROM node:22.22.1-trixie-slim AS node22
+FROM node:23.11.1-bookworm-slim AS node23
+FROM node:24.13.0-trixie-slim AS node24
+FROM node:25.8.1-trixie-slim AS node25
+
+FROM node:24.13.0-trixie-slim
+
+# install build deps and set locale (Preset locale to en_US.UTF-8)
+RUN apt-get update && apt-get install -y \
+      curl \
+      git \
+      git-lfs \
+      libsecret-1-dev \
+      libx11-dev \
+      libxkbfile-dev \
+      locales \
+      node-gyp \
+      pkg-config \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* \
+    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
+
+ENV NODENV_ROOT=/opt/nodenv
+ENV PATH="$NODENV_ROOT/shims:$NODENV_ROOT/bin:$PATH"
+
+# Install nodenv
+RUN nodenv_version="v1.6.2" \
+  && git clone https://github.com/nodenv/nodenv.git ${NODENV_ROOT} \
+  && cd ${NODENV_ROOT} && git checkout ${nodenv_version} \
+  && node_build_version="v5.4.30" \
+  && git clone https://github.com/nodenv/node-build.git ${NODENV_ROOT}/plugins/node-build \
+  && cd ${NODENV_ROOT}/plugins/node-build && git checkout ${node_build_version} \
+  && git clone https://github.com/nodenv/node-build-jxcore.git $(nodenv root)/plugins/node-build-jxcore \
+  && cd $(nodenv root)/plugins/node-build-jxcore && git checkout 1b6cdf343b767e77b9f1522d5c9fa111c5373794 \
+  && npm_migrate_version="v0.1.1" \
+  && git clone https://github.com/nodenv/nodenv-npm-migrate.git ${NODENV_ROOT}/plugins/nodenv-npm-migrate \
+  && cd ${NODENV_ROOT}/plugins/nodenv-npm-migrate && git checkout ${npm_migrate_version} \
+  && find ${NODENV_ROOT} -type d -name ".git" -exec rm -r "{}" \+ \
+  && curl -fsSL https://github.com/nodenv/nodenv-installer/raw/master/bin/nodenv-doctor | bash \
+  && nodenv install --list
+
+
+# Install all latest major Nodejs versions excludes older than one year since EOL.
+# https://github.com/nodejs/Release#end-of-life-releases
+
+ENV ROCRO_NODE18=18.20.8
+ENV ROCRO_NODE20=20.20.1
+ENV ROCRO_NODE22=22.22.1
+ENV ROCRO_NODE23=23.11.1
+ENV ROCRO_NODE24=24.13.0
+ENV ROCRO_NODE25=25.8.1
+ENV ROCRO_PREINSTALLED_VERSIONS="\
+${ROCRO_NODE18}\n\
+${ROCRO_NODE20}\n\
+${ROCRO_NODE22}\n\
+${ROCRO_NODE23}\n\
+${ROCRO_NODE24}\n\
+${ROCRO_NODE25}"
+
+COPY --from=node18 "/usr/local/bin/node" "${NODENV_ROOT}/versions/${ROCRO_NODE18}/bin/"
+COPY --from=node20 "/usr/local/bin/node" "${NODENV_ROOT}/versions/${ROCRO_NODE20}/bin/"
+COPY --from=node22 "/usr/local/bin/node" "${NODENV_ROOT}/versions/${ROCRO_NODE22}/bin/"
+COPY --from=node23 "/usr/local/bin/node" "${NODENV_ROOT}/versions/${ROCRO_NODE23}/bin/"
+COPY --from=node24 "/usr/local/bin/node" "${NODENV_ROOT}/versions/${ROCRO_NODE24}/bin/"
+COPY --from=node25 "/usr/local/bin/node" "${NODENV_ROOT}/versions/${ROCRO_NODE25}/bin/"
+
+COPY --from=node18 "/usr/local/lib/node_modules" "${NODENV_ROOT}/versions/${ROCRO_NODE18}/lib/node_modules"
+COPY --from=node20 "/usr/local/lib/node_modules" "${NODENV_ROOT}/versions/${ROCRO_NODE20}/lib/node_modules"
+COPY --from=node22 "/usr/local/lib/node_modules" "${NODENV_ROOT}/versions/${ROCRO_NODE22}/lib/node_modules"
+COPY --from=node23 "/usr/local/lib/node_modules" "${NODENV_ROOT}/versions/${ROCRO_NODE23}/lib/node_modules"
+COPY --from=node24 "/usr/local/lib/node_modules" "${NODENV_ROOT}/versions/${ROCRO_NODE24}/lib/node_modules"
+COPY --from=node25 "/usr/local/lib/node_modules" "${NODENV_ROOT}/versions/${ROCRO_NODE25}/lib/node_modules"
+
+RUN mkdir -p "${NODENV_ROOT}/versions/${ROCRO_NODE20}/bin/" "${NODENV_ROOT}/versions/${ROCRO_NODE20}/lib/" \
+    && cp "$(nodenv which node)" "${NODENV_ROOT}/versions/${ROCRO_NODE20}/bin/" \
+    && cp -R "/usr/local/lib/node_modules" "${NODENV_ROOT}/versions/${ROCRO_NODE20}/lib/" \
+    && echo ${ROCRO_PREINSTALLED_VERSIONS} | while read version;do \
+      npm install -g pnpm@10.12.1 \
+      && NPM_SRC="${NODENV_ROOT}/versions/${version}/lib/node_modules/npm/bin/npm-cli.js" \
+      && NPM_DST="${NODENV_ROOT}/versions/${version}/bin/npm" \
+      # Override the shebang line of npm-cli.js to use the "node" path dynamically.
+      && sed -i -E "1s/#.+/#!\/usr\/bin\/env node/" "${NPM_SRC}" \
+      && ln -s -f "${NPM_SRC}" "${NPM_DST}";done \
+    && nodenv rehash \
+    && npm set progress false --global --quiet \
+    && [ "$(nodenv versions --bare | xargs)" = "$ROCRO_NODE18 $ROCRO_NODE20 $ROCRO_NODE22 $ROCRO_NODE23 $ROCRO_NODE24 $ROCRO_NODE25" ]

--- a/24.2.0-trixie/Dockerfile
+++ b/24.2.0-trixie/Dockerfile
@@ -1,0 +1,87 @@
+FROM node:18.20.8-bookworm-slim AS node18
+FROM node:20.19.2-bookworm-slim AS node20
+FROM node:22.16.0-bookworm-slim AS node22
+FROM node:23.11.1-bookworm-slim AS node23
+FROM node:24.12.0-bookworm-slim AS node24
+
+FROM node:24.12.0-trixie-slim
+
+# install build deps and set locale (Preset locale to en_US.UTF-8)
+RUN apt-get update && apt-get install -y \
+      curl \
+      git \
+      git-lfs \
+      libsecret-1-dev \
+      libx11-dev \
+      libxkbfile-dev \
+      locales \
+      node-gyp \
+      pkg-config \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* \
+    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+ENV NODENV_ROOT /opt/nodenv
+ENV PATH "$NODENV_ROOT/shims:$NODENV_ROOT/bin:$PATH"
+
+# Install nodenv
+RUN nodenv_version="v1.5.0" \
+  && git clone https://github.com/nodenv/nodenv.git ${NODENV_ROOT} \
+  && cd ${NODENV_ROOT} && git checkout ${nodenv_version} \
+  && src/configure && make -C src \
+  && node_build_version="v5.4.3" \
+  && git clone https://github.com/nodenv/node-build.git ${NODENV_ROOT}/plugins/node-build \
+  && cd ${NODENV_ROOT}/plugins/node-build && git checkout ${node_build_version} \
+  && git clone https://github.com/nodenv/node-build-jxcore.git $(nodenv root)/plugins/node-build-jxcore \
+  && cd $(nodenv root)/plugins/node-build-jxcore && git checkout 1b6cdf343b767e77b9f1522d5c9fa111c5373794 \
+  && npm_migrate_version="v0.1.1" \
+  && git clone https://github.com/nodenv/nodenv-npm-migrate.git ${NODENV_ROOT}/plugins/nodenv-npm-migrate \
+  && cd ${NODENV_ROOT}/plugins/nodenv-npm-migrate && git checkout ${npm_migrate_version} \
+  && find ${NODENV_ROOT} -type d -name ".git" -exec rm -r "{}" \+ \
+  && curl -fsSL https://github.com/nodenv/nodenv-installer/raw/master/bin/nodenv-doctor | bash \
+  && nodenv install --list
+
+
+# Install all latest major Nodejs versions excludes older than one year since EOL.
+# https://github.com/nodejs/Release#end-of-life-releases
+
+ENV ROCRO_NODE18 "18.20.8"
+ENV ROCRO_NODE20 "20.19.2"
+ENV ROCRO_NODE22 "22.16.0"
+ENV ROCRO_NODE23 "23.11.1"
+ENV ROCRO_NODE24 "24.12.0"
+ENV ROCRO_PREINSTALLED_VERSIONS  "\
+${ROCRO_NODE18}\n\
+${ROCRO_NODE20}\n\
+${ROCRO_NODE22}\n\
+${ROCRO_NODE23}\n\
+${ROCRO_NODE24}"
+
+COPY --from=node18 "/usr/local/bin/node" "${NODENV_ROOT}/versions/${ROCRO_NODE18}/bin/"
+COPY --from=node20 "/usr/local/bin/node" "${NODENV_ROOT}/versions/${ROCRO_NODE20}/bin/"
+COPY --from=node22 "/usr/local/bin/node" "${NODENV_ROOT}/versions/${ROCRO_NODE22}/bin/"
+COPY --from=node23 "/usr/local/bin/node" "${NODENV_ROOT}/versions/${ROCRO_NODE23}/bin/"
+COPY --from=node24 "/usr/local/bin/node" "${NODENV_ROOT}/versions/${ROCRO_NODE24}/bin/"
+
+COPY --from=node18 "/usr/local/lib/node_modules" "${NODENV_ROOT}/versions/${ROCRO_NODE18}/lib/node_modules"
+COPY --from=node20 "/usr/local/lib/node_modules" "${NODENV_ROOT}/versions/${ROCRO_NODE20}/lib/node_modules"
+COPY --from=node22 "/usr/local/lib/node_modules" "${NODENV_ROOT}/versions/${ROCRO_NODE22}/lib/node_modules"
+COPY --from=node23 "/usr/local/lib/node_modules" "${NODENV_ROOT}/versions/${ROCRO_NODE23}/lib/node_modules"
+COPY --from=node24 "/usr/local/lib/node_modules" "${NODENV_ROOT}/versions/${ROCRO_NODE24}/lib/node_modules"
+
+RUN mkdir -p "${NODENV_ROOT}/versions/${ROCRO_NODE20}/bin/" "${NODENV_ROOT}/versions/${ROCRO_NODE20}/lib/" \
+    && cp "$(nodenv which node)" "${NODENV_ROOT}/versions/${ROCRO_NODE20}/bin/" \
+    && cp -R "/usr/local/lib/node_modules" "${NODENV_ROOT}/versions/${ROCRO_NODE20}/lib/" \
+    && echo ${ROCRO_PREINSTALLED_VERSIONS} | while read version;do \
+      npm install -g pnpm@10.12.1 \
+      && NPM_SRC="${NODENV_ROOT}/versions/${version}/lib/node_modules/npm/bin/npm-cli.js" \
+      && NPM_DST="${NODENV_ROOT}/versions/${version}/bin/npm" \
+      # Override the shebang line of npm-cli.js to use the "node" path dynamically.
+      && sed -i -E "1s/#.+/#!\/usr\/bin\/env node/" "${NPM_SRC}" \
+      && ln -s -f "${NPM_SRC}" "${NPM_DST}";done \
+    && nodenv rehash \
+    && npm set progress false --global --quiet \
+    && [ "$(nodenv versions --bare | xargs)" = "$ROCRO_NODE18 $ROCRO_NODE20 $ROCRO_NODE22 $ROCRO_NODE23 $ROCRO_NODE24" ]


### PR DESCRIPTION
baseimageをtrixieへ更新しました。Nodeのバージョンを24.13.0へ更新しました。
ベースイメージはnode24としています。現状の最新LTS

dockerhubには以下のタグでpushしています。
~`conchoid/docker-nodenv:v1.5.0-1-24.12.0-trixie`~

dockerhubには以下のタグでpushしています。
docker pull conchoid/docker-nodenv:v1.6.2-1-24.13.0-bookworm
docker pull conchoid/docker-nodenv:v1.6.2-1-24.13.0-trixie


